### PR TITLE
Rename instruction content field to instructions

### DIFF
--- a/app/routers/instructions_api.py
+++ b/app/routers/instructions_api.py
@@ -111,7 +111,7 @@ async def parse_instructions_file(
         if not text_content:
             raise HTTPException(status_code=400, detail="File appears to be empty or could not be parsed")
         
-        return {"content": text_content}
+        return {"instructions": text_content}
         
     except Exception as e:
         logging.error(f"Error parsing instructions file: {e}")

--- a/frontend/src/services/instructions.ts
+++ b/frontend/src/services/instructions.ts
@@ -2,7 +2,7 @@ import { apiService } from './api'
 
 export interface Instruction {
   id?: number
-  content: string
+  instructions: string
   created_at?: string
   updated_at?: string
 }
@@ -21,11 +21,11 @@ export class InstructionsService {
     return await apiService.get('/instructions')
   }
 
-  async updateInstructions(content: string): Promise<Instruction> {
-    return await apiService.post('/instructions', { content })
+  async updateInstructions(instructions: string): Promise<Instruction> {
+    return await apiService.post('/instructions', { instructions })
   }
 
-  async parseInstructionsFile(file: File): Promise<{ content: string }> {
+  async parseInstructionsFile(file: File): Promise<{ instructions: string }> {
     const formData = new FormData()
     formData.append('file', file)
     return await apiService.upload('/parse-instructions-file', formData)

--- a/frontend/src/views/Instructions.vue
+++ b/frontend/src/views/Instructions.vue
@@ -643,7 +643,7 @@ const uploadInstructionFile = async () => {
       }
     })
     
-    instructionForm.value.instructions = response.content
+    instructionForm.value.instructions = response.instructions
     showSuccess('File parsed successfully!')
     clearInstructionFile()
     openInstructionModal()


### PR DESCRIPTION
## Summary
- rename instruction interface field from `content` to `instructions`
- send `instructions` in update and parse calls
- adjust file upload view and API to use `instructions`

## Testing
- `npm test -- --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af85519f14832186175982da032cc5