### PR TITLE
refactor api getDirect

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -96,8 +96,7 @@ class ApiService {
 
   // Direct GET method that doesn't wrap params
   async getDirect<T>(endpoint: string, params?: any): Promise<T> {
-    const response = await this.api.get(endpoint, { params })
-    return response.data
+    return await this.api.get(endpoint, { params })
   }
 
   async post<T>(endpoint: string, data?: any, config?: any): Promise<T> {


### PR DESCRIPTION
## Summary
- simplify ApiService.getDirect to return axios response

## Testing
- `node test-getDirect.mjs`
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_b_68af86f36b2c8321ae5cec21e876186e