### PR TITLE
Require session id for chat service

### DIFF
--- a/frontend/src/services/chat.ts
+++ b/frontend/src/services/chat.ts
@@ -25,7 +25,7 @@ export interface ChatMemory {
 
 export class ChatService {
   // Chat API endpoints
-  async sendMessage(message: string, sessionId?: number): Promise<ChatMessage> {
+  async sendMessage(message: string, sessionId: number): Promise<ChatMessage> {
     return await apiService.post('/chat', {
       message,
       session_id: sessionId

--- a/static/index.html
+++ b/static/index.html
@@ -45,6 +45,7 @@
         // The history sent to the backend should only contain the actual conversation.
         // The initial greeting is already in the HTML for the UI.
         let history = [];
+        let sessionId = null;
 
         const toggleSendButton = () => {
             sendBtn.disabled = input.value.trim() === '';
@@ -68,6 +69,13 @@
             input.value = '';
             toggleSendButton();
 
+            // Create session if needed
+            if (!sessionId) {
+                const sessionRes = await fetch('/api/chat-sessions', { method: 'POST' });
+                const sessionData = await sessionRes.json();
+                sessionId = sessionData.session_id;
+            }
+
             // Create a placeholder for the assistant's response
             const assistantMsgDiv = addMessage('', 'assistant');
             assistantMsgDiv.innerHTML = 'Thinking...';
@@ -76,7 +84,7 @@
                 const response = await fetch('/api/chat', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ history: history })
+                    body: JSON.stringify({ message: userInput, session_id: sessionId })
                 });
 
                 if (!response.body) throw new Error("No response body");


### PR DESCRIPTION
## Summary
- require session id when sending messages
- create sessions for the static chat page and send session id with message

## Testing
- `npm test` (fails: vitest: Permission denied)

------
https://chatgpt.com/codex/tasks/task_b_68af8b75ae4883218f0d37b37449155b