### PR TITLE
refactor: update reports service to use date range

### DIFF
--- a/frontend/src/services/reports.ts
+++ b/frontend/src/services/reports.ts
@@ -35,8 +35,8 @@ export interface DashboardStats {
 }
 
 export class ReportsService {
-  async getReports(days?: number): Promise<ReportData[]> {
-    return await apiService.get('/reports', days ? { days } : undefined)
+  async getReports(params: { fromdate: string; todate: string }): Promise<ReportData[]> {
+    return await apiService.get('/reports', { fromdate: params.fromdate, todate: params.todate })
   }
 
   async getDashboardStats(days?: number): Promise<DashboardStats> {

--- a/frontend/src/views/Reports.vue
+++ b/frontend/src/views/Reports.vue
@@ -502,6 +502,13 @@ const loadReports = async () => {
   isLoadingCharts.value = true
 
   try {
+    // Determine date range for reports
+    const to = new Date()
+    const todate = to.toISOString().split('T')[0]
+    const from = new Date()
+    from.setDate(from.getDate() - Number(selectedPeriod.value))
+    const fromdate = from.toISOString().split('T')[0]
+
     // Load summary stats
     const statsResponse = await reportsService.getDashboardStats(Number(selectedPeriod.value))
 
@@ -514,7 +521,7 @@ const loadReports = async () => {
     })
 
     // Load detailed reports
-    const reportsResponse = await reportsService.getReports(Number(selectedPeriod.value))
+    const reportsResponse = await reportsService.getReports({ fromdate, todate })
     reports.value = Array.isArray(reportsResponse) ? reportsResponse : []
 
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- refactor reports service to request reports by from/to date range
- compute selected date range in reports view and pass to service

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68af8b7bc0a48321816f49b7cc66a9df