### PR TITLE
Return updated profile fields

### DIFF
--- a/app/routers/user_api.py
+++ b/app/routers/user_api.py
@@ -33,8 +33,21 @@ async def update_user_settings(
             raise HTTPException(status_code=400, detail="Passwords do not match.")
         if len(settings_data.new_password) < 8:
             raise HTTPException(status_code=400, detail="Password must be at least 8 characters long.")
-        
+
         user.hashed_password = hashing.Hash.bcrypt(settings_data.new_password)
 
     db.commit()
-    return {"message": "Settings updated successfully."}
+    db.refresh(profile)
+
+    profile_data = {
+        "first_name": profile.first_name,
+        "last_name": profile.last_name,
+        "xelence_x_api_key": profile.xelence_x_api_key,
+        "xelence_affiliateid": profile.xelence_affiliateid,
+        "chat_rate": profile.chat_rate,
+    }
+
+    return {
+        "message": "Settings updated successfully.",
+        "profile": profile_data,
+    }

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { apiService } from '@/services/api'
-import type { User, LoginCredentials, SignupData, UserProfileUpdate } from '@/types/auth'
+import type { User, LoginCredentials, SignupData, UserProfileUpdate, UserProfile } from '@/types/auth'
 
 export const useAuthStore = defineStore('auth', () => {
   const user = ref<User | null>(null)
@@ -95,11 +95,11 @@ export const useAuthStore = defineStore('auth', () => {
   const updateProfile = async (data: UserProfileUpdate) => {
     isLoading.value = true
     error.value = null
-    
+
     try {
-      const response = await apiService.post('/settings', data)
-      if (user.value) {
-        user.value.profile = { ...(user.value.profile || {}), ...response }
+      const response = await apiService.post<{ message: string; profile: UserProfile }>('/settings', data)
+      if (user.value && response.profile) {
+        user.value.profile = { ...(user.value.profile || {}), ...response.profile }
       }
       return response
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- return updated profile data alongside settings update message
- merge returned profile data in auth store and ignore message

## Testing
- `pytest`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68af8b7f0cac8321879c853679d6dfde