### PR TITLE
Use httpx for async external requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ python-multipart          # For FastAPI file uploads
 sqlalchemy                # For database ORM
 python-jose[cryptography] # For JWT tokens
 passlib[bcrypt]           # For password hashing
-requests
-httpx                     # For async HTTP requests to Kommo
+httpx                     # For async HTTP requests
 itsdangerous              # For signing session cookies for flash messages
 xmltodict
 protobuf


### PR DESCRIPTION
## Summary
- refactor reports endpoint to use `httpx.AsyncClient` with timeout and error handling
- switch Kommo client helper to `httpx.AsyncClient`
- drop unused `requests` dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af8b836c388321a9be5d24a346e291