### PR TITLE
refactor: align User type with API fields

### DIFF
--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,12 +1,8 @@
 export interface User {
   id: number
   username: string
-  email: string
-  is_active: boolean
-  created_at: string
-  updated_at: string
+  email?: string
   kommo_integration_key?: string
-  kommo_widget_installed?: boolean
   profile?: UserProfile
 }
 
@@ -34,6 +30,7 @@ export interface UserProfile {
   xelence_x_api_key?: string
   xelence_affiliateid?: string
   chat_rate?: number
+  kommo_widget_installed?: boolean
 }
 
 export interface UserProfileUpdate extends UserProfile {


### PR DESCRIPTION
## Summary
- align `User` interface with API responses by removing unused fields and making others optional
- move `kommo_widget_installed` to `UserProfile`

## Testing
- `npm run build:check` *(fails: Search string not found: "/supportedTSExtensions = .*(?=;)/")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af8b8630c883218c376d35265157a6