### PR TITLE
Allow setting FAQ priority

### DIFF
--- a/frontend/src/services/instructions.ts
+++ b/frontend/src/services/instructions.ts
@@ -11,6 +11,7 @@ export interface FAQ {
   id?: number
   question: string
   answer: string
+  priority?: number
   created_at?: string
   updated_at?: string
 }
@@ -36,12 +37,17 @@ export class InstructionsService {
     return await apiService.get('/faqs')
   }
 
-  async createFAQ(question: string, answer: string): Promise<FAQ> {
-    return await apiService.post('/faqs', { question, answer })
+  async createFAQ(question: string, answer: string, priority?: number): Promise<FAQ> {
+    return await apiService.post('/faqs', { question, answer, priority })
   }
 
-  async updateFAQ(id: number, question: string, answer: string): Promise<FAQ> {
-    return await apiService.put(`/faqs/${id}`, { question, answer })
+  async updateFAQ(
+    id: number,
+    question: string,
+    answer: string,
+    priority?: number
+  ): Promise<FAQ> {
+    return await apiService.put(`/faqs/${id}`, { question, answer, priority })
   }
 
   async deleteFAQ(id: number): Promise<void> {

--- a/frontend/src/views/Instructions.vue
+++ b/frontend/src/views/Instructions.vue
@@ -453,6 +453,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { apiService } from '@/services/api'
+import type { FAQ } from '@/services/instructions'
 import BaseLayout from '@/components/BaseLayout.vue'
 import BaseCard from '@/components/BaseCard.vue'
 import BaseButton from '@/components/BaseButton.vue'
@@ -480,16 +481,16 @@ const instructionFileInput = ref(null)
 const isUploadingInstruction = ref(false)
 
 // FAQs state
-const faqs = ref([])
+const faqs = ref<FAQ[]>([])
 const isLoadingFaqs = ref(false)
 const showFaqModal = ref(false)
-const editingFaq = ref(null)
-const faqForm = ref({
+const editingFaq = ref<FAQ | null>(null)
+const faqForm = ref<FAQ>({
   question: '',
   answer: '',
   priority: 1
 })
-const faqErrors = ref({})
+const faqErrors = ref<Record<string, string>>({})
 const isSavingFaq = ref(false)
 const faqSearchQuery = ref('')
 
@@ -679,7 +680,7 @@ const openFaqModal = () => {
   showFaqModal.value = true
 }
 
-const editFaq = (faq) => {
+const editFaq = (faq: FAQ) => {
   editingFaq.value = faq
   faqForm.value = {
     question: faq.question,


### PR DESCRIPTION
## Summary
- add optional `priority` to FAQ type and service methods
- expose priority editing and display in instructions view

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68af8b893ec883218dde1997e9acb223