### PR TITLE
Handle Kommo chat webhooks and send AI responses

### DIFF
--- a/app/kommo_client.py
+++ b/app/kommo_client.py
@@ -111,3 +111,12 @@ class KommoClient:
     async def get_deals(self, limit: int = 50, page: int = 1) -> List[Dict]:
         res = await self._request("GET", "deals", params={"limit": limit, "page": page})
         return (res or {}).get("_embedded", {}).get("deals", [])
+
+    async def send_chat_message(self, conversation_id: str, text: str) -> bool:
+        """Send a message back to a Kommo chat conversation."""
+        payload = {
+            "conversation": {"id": conversation_id},
+            "message": {"text": text}
+        }
+        res = await self._request("POST", "chats/messages", json_body=payload)
+        return bool(res)


### PR DESCRIPTION
## Summary
- initialize Gemini client for Kommo webhooks and reply to chat messages automatically
- send chat messages back to Kommo using new `send_chat_message` helper
- process Kommo webhooks in background tasks and trigger AI response flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af8eb6e3588321a513b713d2b82eee