### PR TITLE
Handle optional widget provenance field

### DIFF
--- a/app/routers/kommo_api.py
+++ b/app/routers/kommo_api.py
@@ -45,6 +45,14 @@ class ConfigureJSON(BaseModel):
     refresh_token: Optional[str] = None
     webhook_secret: Optional[str] = None
 
+
+class WidgetRequestPayload(BaseModel):
+    message: str
+    chat_id: str
+    lead_id: Optional[str] = None
+    visitor_id: Optional[str] = None
+    from_: Optional[str] = Field(None, alias="from")
+
 # -------------------------------
 # Status
 # -------------------------------
@@ -202,6 +210,16 @@ async def test_integration(
     if not res.get("success"):
         raise HTTPException(status_code=400, detail="Unable to reach Kommo API")
 
+    return {"status": "ok"}
+
+# -------------------------------
+# Widget request endpoint
+# -------------------------------
+@router.post("/kommo/widget-request")
+async def widget_request(payload: WidgetRequestPayload):
+    """Handle inbound requests from the Kommo Salesbot widget."""
+    source = payload.from_ or "unknown"
+    logger.info(f"Received widget request from {source}: {payload.dict()}")
     return {"status": "ok"}
 
 # -------------------------------

--- a/widgets/shared/script.js
+++ b/widgets/shared/script.js
@@ -38,7 +38,6 @@ define(['jquery'], function($){
 
                     // Data we want to send to your server on every inbound message:
                     const requestData = {
-                      from: 'widget',
                       // message_text comes from the previous step (Incoming message)
                       message: '{{message_text}}',
                       chat_id: '{{chat_id}}',


### PR DESCRIPTION
## Summary
- remove hardcoded `from: 'widget'` field from widget request payload
- add `WidgetRequestPayload` schema with optional `from` and new endpoint logging provenance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af94c01c8c8321a579b7dbc3831355