### PR TITLE
Rename account setting to subdomain

### DIFF
--- a/Kommo_Widget/i18n/en.json
+++ b/Kommo_Widget/i18n/en.json
@@ -8,6 +8,6 @@
     "settings":{
         "login":"User login",
         "api_key":"API key",
-        "account":"Account"
+        "subdomain":"Subdomain"
     }
 }

--- a/Kommo_Widget/i18n/es.json
+++ b/Kommo_Widget/i18n/es.json
@@ -8,6 +8,6 @@
     "settings":{
         "login":"Inicio de sesión",
         "api_key":"Clave API",
-        "account":"Cuenta"
+        "subdomain":"Subdominio"
     }
 }

--- a/Kommo_Widget/i18n/pt.json
+++ b/Kommo_Widget/i18n/pt.json
@@ -8,6 +8,6 @@
     "settings":{
         "login":"Conecte-se",
         "api_key":"Chave API",
-        "account":"Conta"
+        "subdomain":"Subdomínio"
     }
 }

--- a/Kommo_Widget/manifest.json
+++ b/Kommo_Widget/manifest.json
@@ -48,8 +48,8 @@
       "type": "text",
       "required": true
     },
-    "account": {
-      "name": "settings.account",
+    "subdomain": {
+      "name": "settings.subdomain",
       "type": "text",
       "required": true
     }

--- a/widgets/shared/i18n/en.json
+++ b/widgets/shared/i18n/en.json
@@ -12,6 +12,6 @@
   "settings": {
     "login": "User login",
     "api_key": "API key",
-    "account": "Account"
+    "subdomain": "Subdomain"
   }
 }

--- a/widgets/shared/i18n/es.json
+++ b/widgets/shared/i18n/es.json
@@ -8,7 +8,7 @@
     "settings":{
         "login":"Usuario",
         "api_key":"Clave API",
-        "account":"Cuenta"
+        "subdomain":"Subdominio"
     },
     "salesbot":{
         "handler_name":"Puente de IA",

--- a/widgets/shared/i18n/pt.json
+++ b/widgets/shared/i18n/pt.json
@@ -8,7 +8,7 @@
     "settings":{
         "login":"Usuário",
         "api_key":"Chave da API",
-        "account":"Conta"
+        "subdomain":"Subdomínio"
     },
     "salesbot":{
         "handler_name":"Ponte de IA",

--- a/widgets/shared/manifest.json
+++ b/widgets/shared/manifest.json
@@ -44,8 +44,8 @@
       "type": "text",
       "required": true
     },
-    "account": {
-      "name": "settings.account",
+    "subdomain": {
+      "name": "settings.subdomain",
       "type": "text",
       "required": true
     }


### PR DESCRIPTION
## Summary
- rename `account` setting to `subdomain` in widget manifests
- update i18n keys and translations for the new `subdomain` field

## Testing
- `pytest`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68af94bfc7848321b76d7b2a425cfb19