### PR TITLE
feat: add dynamic API base for Kommo widget

### DIFF
--- a/widgets/README.md
+++ b/widgets/README.md
@@ -1,0 +1,25 @@
+# Widget Build Instructions
+
+The Salesbot widget manifest uses a configurable API base URL.
+
+## Generating `manifest.json`
+
+Set the `PRODUCTION_API_BASE` environment variable and run the build script:
+
+```bash
+PRODUCTION_API_BASE=https://api.example.com python widgets/build_manifest.py
+```
+
+This replaces the `${API_BASE}` token in `shared/manifest.json` with your
+production API domain.
+
+## Integration Key Placeholder
+
+The webhook URL in the manifest contains a `{integration_key}` token:
+
+```
+${API_BASE}/api/kommo/kommo/widget-request/{integration_key}
+```
+
+Keep this placeholder in the final URL. At runtime it must be replaced with
+an actual integration key so the request is routed to the correct account.

--- a/widgets/build_manifest.py
+++ b/widgets/build_manifest.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Inject production API base into widget manifest.
+
+Reads widgets/shared/manifest.json and replaces the ${API_BASE} token with
+PRODUCTION_API_BASE environment variable. The {integration_key} placeholder
+is preserved so the runtime can substitute the user's key.
+"""
+
+import json
+import os
+from pathlib import Path
+
+API_BASE = os.environ.get("PRODUCTION_API_BASE")
+if not API_BASE:
+    raise SystemExit("PRODUCTION_API_BASE environment variable is required")
+
+manifest_path = Path(__file__).parent / "shared" / "manifest.json"
+manifest = json.loads(manifest_path.read_text())
+
+# Replace placeholder token
+placeholder = manifest["salesbot_designer"]["handler_name"]["settings"]["text"]["default_value"]
+manifest["salesbot_designer"]["handler_name"]["settings"]["text"]["default_value"] = (
+    placeholder.replace("${API_BASE}", API_BASE.rstrip("/"))
+)
+
+manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+print(f"Updated manifest default_value to use {API_BASE.rstrip('/')}")

--- a/widgets/shared/manifest.json
+++ b/widgets/shared/manifest.json
@@ -57,7 +57,7 @@
       "settings": {
         "text": {
           "name": "salesbot.text",
-          "default_value": "https://9dfbf46b7e88.ngrok-free.app/api/kommo/kommo/widget-request",
+          "default_value": "${API_BASE}/api/kommo/kommo/widget-request/{integration_key}",
           "type": "text",
           "manual": true
         }


### PR DESCRIPTION
## Summary
- replace ngrok placeholder with `${API_BASE}` token and keep `{integration_key}` in webhook URL
- add build script that injects production API base into widget manifest
- document how to build the manifest and retain the `{integration_key}` placeholder

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: Permission denied for vitest)*

------
https://chatgpt.com/codex/tasks/task_b_68af94b987708321a80c4d771d8e6a11